### PR TITLE
update dependencies

### DIFF
--- a/hightable/package.json
+++ b/hightable/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "hightable": "0.13.3",
+    "hightable": "0.13.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router": "7.4.1"

--- a/hyparquet/package.json
+++ b/hyparquet/package.json
@@ -14,8 +14,8 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "hyperparam": "0.2.30",
-    "hightable": "0.13.3",
+    "hyperparam": "0.2.31",
+    "hightable": "0.13.4",
     "hyparquet": "1.10.2",
     "hyparquet-compressors": "1.1.1",
     "react": "18.3.1",

--- a/hyparquet/package.json
+++ b/hyparquet/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "hyperparam": "0.2.31",
     "hightable": "0.13.4",
-    "hyparquet": "1.10.2",
+    "hyparquet": "1.10.3",
     "hyparquet-compressors": "1.1.1",
     "react": "18.3.1",
     "react-dom": "18.3.1"


### PR DESCRIPTION
Requires https://github.com/hyparam/hightable/pull/97 + https://github.com/hyparam/hyperparam-cli/pull/201 before (tests are failing meanwhile because 0.13.4 and 0.2.31 have not been published yet).