### PR TITLE
update hightable and implement dataframe v2

### DIFF
--- a/icebird/package.json
+++ b/icebird/package.json
@@ -14,8 +14,8 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "hightable": "0.17.0",
-    "hyperparam": "0.2.48",
+    "hightable": "0.18.1",
+    "hyperparam": "0.3.7",
     "icebird": "0.3.0",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/icebird/src/Page.tsx
+++ b/icebird/src/Page.tsx
@@ -9,7 +9,7 @@ export interface PageProps {
   versions: string[]
   version: string
   setVersion: (version: string) => void
-  setError: (e: Error) => void
+  setError: (e: unknown) => void
 }
 
 /**


### PR DESCRIPTION
@platypii do you want to review this one?

I'm not really sure about the dataframe I created for the iceberg files.

Three things to think about:
- how to handle the case where the file contains less than the estimated `numRows`. In this implementation, I put `-1` in the row number (as we only support numbers - it could also be NaN)  and `undefined` in the cells
- I'm not sure how icebergRead works, but I fear it has to fetch from the first row, even if we ask for `[1000, 2000]`. Is it right? If so, do you have an idea of how we could improve? maybe asking for `[0, rowEnd]` and cache everything to avoid later fetches (consumes more memory)
- Currently, if we scroll slowly, we send a lot of icebergRead for one or two rows. We could improve by batching by 1000 rows (a bit like VirtualRowGroup in hyperparam-cli)

Re cache: we might want to implement https://github.com/hyparam/hightable/issues/232, and use it here, to simplify the cache management.
